### PR TITLE
Device Requirements & Maintainers' Code of Conduct Rewrite

### DIFF
--- a/device_requirements.md
+++ b/device_requirements.md
@@ -2,46 +2,70 @@
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
-1. Device or software exceptions **SHOULD** be made via change request to this repository.
+Exceptions **SHOULD** be made by contacting the administration team.
 
-2. The device **MAY** have SELinux Enforcing.
-
-3. The device **MUST** have hardware compatibility comparable to stock ROMs (i.e. if IR blaster works on stock ROMs, it **MUST** work on PE) 
+- **MUST** 
+ 
+  - Upload the device's buildable sources to [PixelExperience-Devices](https://github.com/PixelExperience-Devices) organization. 
   
-4. The device's trees are **REQUIRED** to include some commits listed [here](https://github.com/PixelExperience-Devices/required_commits).
-
-5. The device **MUST** pass SafetyNet out of the box with no modifications.
-  
-    5.1. If the device's stock fingeprint passes, it **MUST** be used.
+  - Have hardware compatibility comparable to stock ROMs.
     
-    5.2. If that device's stock fingerprint does not pass SafetyNet, other devices' fingeprints (e.g. Pixels' fingerprints) **SHOULD** be used.
+  - Include some commits listed [here](https://github.com/PixelExperience-Devices/required_commits) in device's trees.
+    
+  - Ship builds with AOSP recovery available by us for devices using A/B or dynamic parition layout.
+    
+  - Pass SafetyNet out of the box with no modifications. Other devices' fingerprint **SHOULD** be used if stock device's fingeprint does not pass SafetyNet.
 
-6. The device **MUST NOT** include, but is not limited to:
+- **MUST NOT**
 
-    6.1. Packages that are not built, do not work, and/or are obsolete.
+  - Ship Google Play System Updates/Updatable APEX enabled if the device uses kernel version 3.18 or below, or uses Full Disk Encryption (a.k.a FDE).
+    
+  - Ship builds with pre-built kernels, unless it's the only solution to make the device functional.
+    
+  - Ship builds with pre-built TWRP if the device uses A/B partition or dynamic parition layout.
+
+  - Inlucde any features in their device-specific packages (i.e. configpanel, XiaomiParts, ...).
+    
+  - Include any Google applications or similar applications to getting Pixel-like features that aren't available from the ROM sources.
+    
+  - Include any stock firmware camera app.
+
+  - Include packages that are not built, do not work, and/or are obsolete.
   
-    6.2. Placebo 'tweaks' and/or packages that contain unnecessary and/or unwanted features, as stated in #6 of [Maintainers' Code of Conduct](https://github.com/PixelExperience/docs/blob/master/maintainers_code_of_conduct.md).
+  - Include placebo 'tweaks' and/or packages that contain unnecessary and/or unwanted features.
+    
+  - Include heavy software modification that may lead to Magisk working improperly
+ 
+- **SHOULD**  <br>
 
-7. The device's sources **MUST** be in accordance with #6, #7, #8, #9, and #10 (if applicable) as stated in [Maintainers' Code of Conduct](https://github.com/PixelExperience/docs/blob/master/maintainers_code_of_conduct.md).
+  - Have SELinux Enforcing.
 
-8. If the device uses Full Disk Encryption (a.k.a FDE) or uses kernel version 3.18 or below, it **MUSTN'T** ship with Google Play System Updates/Updatable APEX enabled, as it only works on devices that use File-Based Encryption (a.k.a FBE) with encryption enabled, and kernel version later than 3.18. 
+- **SHOULD NOT** <br>
 
-9. The device **SHOULD NOT** use a lot of patches.
+   - Contain a lot of patches. 
+    
+# Patches
 
-10. If the device **MUST** use a lot of patches, and/or there are commits needed in repos other than the device-specific's ones, they **MUST**:
-
-    10.1. Be **REQUIRED** for the device to build and/or boot successfully, or to enable a function (i.e. Fingerprint On Display).
+- Be **REQUIRED** for the device to build and/or boot successfully, or to enable a function (i.e. Fingerprint On Display).
   
-    10.2. Have proper authorship.
+- Have proper authorship.
 
-    10.3. Be pushed to [PixelExprience's Gerrit](https://gerrit.pixelexperience.org).
+- Be pushed to [PixelExprience's Gerrit](https://gerrit.pixelexperience.org).
 
-    10.4. Be as minimal and as polished as possible.
+- Be as minimal and as polished as possible.
 
-    10.5. Be in accordance with #6, #7, #8, #9, and #10 (if applicable) as stated in [Maintainers' Code of Conduct](https://github.com/PixelExperience/docs/blob/master/maintainers_code_of_conduct.md).
-  
-## Exceptions
-Device(s) | Exception | Until
-----------|-----------|-------
-All       | VoLTE     |-------
-All       | NFC       |-------
+- Be in accordance with all requirements above.
+
+# Exceptions
+Device(s)        | Exception(s)                          | Until | Notes
+-----------------|---------------------------------------|-------|-------------------------------------------------------------------------------------
+All              | VoLTE & NFC                           |       |
+All              | Sources Upload                        |       |Must be from LineageOS, TheMuppets or Sony Open Devices Project (SODP) organizations.
+Xiaomi Devices   | Dirac Sound & XiaomiParts             |       |
+OnePlus Devices  | Alert Sliders & Offscreen Gestures    |       |
+Motorola Devices | Fingerprint Gestures & MotoActions    |       |
+
+Software(s)      | Device(s) Exempted | Until | Notes 
+-----------------| -------------------|-------|--------
+Google Camera    | All                |       | Allowed
+ARCore           | All                |       | Allowed

--- a/device_requirements.md
+++ b/device_requirements.md
@@ -1,34 +1,47 @@
 # Device Requirements
 
-- The device may have SELinux Enforcing to release builds.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
-- The device must have complete hardware compatibility corresponding to the stock ROM, i.e. if IR blaster works on the stock ROM, it must work on PE. Only VoLTE is allowed to be ignored, so are NFC payment methods.
+1. Device or software exceptions **SHOULD** be made via change request to this repository.
 
-- The device trees must have some required commits. You can check them at [this url](https://github.com/PixelExperience-Devices/required_commits).
+2. The device **MAY** have SELinux Enforcing.
 
-- The device must pass SafetyNet out of the box, without any 3rd part mods. If any device's stock build fingerprint works to bypass SafetyNet, those must take preference, even though that custom fingerprints (e.g. Pixels Build fingerprints) aren't restricted to be used.
-
-- The device must not include any unused overlays and packages. This includes, but is not limited to, packages not being built, packages that don't work, obsolete packages, placebo 'tweaks' or any packages that will include unnecessary and/or unwanted features, as stated in the rule #6 at [Maintainers Code of Conduct](https://github.com/PixelExperience/docs/blob/master/maintainers_code_of_conduct.md).
-
-- The device sources must be in accordance with rules #6, #7, #8, #9, and also #10, if applicable, stated at [Maintainers Code of Conduct](https://github.com/PixelExperience/docs/blob/master/maintainers_code_of_conduct.md).
-
-- If the device has Full Disk Encryption (a.k.a FDE) mustn't ship/build the Google Play System Updates/Updatable APEX, as the same only works on devices that have File-Base Encryption (FBE) with the device encrypted. The same is applicable for kernel 3.18 or devices with older kernel versions.
-
-- The device mustn't have the need for a lot of patches, and if so, it must be in accordance with the following listing below.
-
-- If there are commits that are needed in repos other than the device-specific ones, they must:
-
-  - Be necessary for the device to build, boot, or even to have a device function working properly (e.g. Fingerprint On Display).
-
-  - Have proper authorship.
-
-  - Be pushed to [Gerrit](https://gerrit.pixelexperience.org).
-
-  - Be as minimal and polished as possible.
-
-  - Be in accordance with rules #6, #7, #8, #9, and also #10, if applicable, stated in [Maintainers Code of Conduct](https://github.com/PixelExperience/docs/blob/master/maintainers_code_of_conduct.md).
+3. The device **MUST** have hardware compatibility comparable to stock ROMs (i.e. if IR blaster works on stock ROMs, it **MUST** work on PE) 
   
-## Exceptions yet made
+4. The device's trees are **REQUIRED** to include some commits listed [here](https://github.com/PixelExperience-Devices/required_commits).
 
+5. The device **MUST** pass SafetyNet out of the box with no modifications.
+  
+    5.1. If the device's stock fingeprint passes, it **MUST** be used.
+    
+    5.2. If that device's stock fingerprint does not pass SafetyNet, other devices' fingeprints (e.g. Pixels' fingerprints) **SHOULD** be used.
+
+6. The device **MUST NOT** include, but is not limited to:
+
+    6.1. Packages that are not built, do not work, and/or are obsolete.
+  
+    6.2. Placebo 'tweaks' and/or packages that contain unnecessary and/or unwanted features, as stated in #6 of [Maintainers' Code of Conduct](https://github.com/PixelExperience/docs/blob/master/maintainers_code_of_conduct.md).
+
+7. The device's sources **MUST** be in accordance with #6, #7, #8, #9, and #10 (if applicable) as stated in [Maintainers' Code of Conduct](https://github.com/PixelExperience/docs/blob/master/maintainers_code_of_conduct.md).
+
+8. If the device uses Full Disk Encryption (a.k.a FDE) or uses kernel version 3.18 or below, it **MUSTN'T** ship with Google Play System Updates/Updatable APEX enabled, as it only works on devices that use File-Based Encryption (a.k.a FBE) with encryption enabled, and kernel version later than 3.18. 
+
+9. The device **SHOULD NOT** use a lot of patches.
+
+10. If the device **MUST** use a lot of patches, and/or there are commits needed in repos other than the device-specific's ones, they **MUST**:
+
+    10.1. Be **REQUIRED** for the device to build and/or boot successfully, or to enable a function (i.e. Fingerprint On Display).
+  
+    10.2. Have proper authorship.
+
+    10.3. Be pushed to [PixelExprience's Gerrit](https://gerrit.pixelexperience.org).
+
+    10.4. Be as minimal and as polished as possible.
+
+    10.5. Be in accordance with #6, #7, #8, #9, and #10 (if applicable) as stated in [Maintainers' Code of Conduct](https://github.com/PixelExperience/docs/blob/master/maintainers_code_of_conduct.md).
+  
+## Exceptions
 Device(s) | Exception | Until
----------:|:---------:|:-------
+----------|-----------|-------
+All       | VoLTE     |-------
+All       | NFC       |-------

--- a/device_requirements.md
+++ b/device_requirements.md
@@ -4,9 +4,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 Exceptions **SHOULD** be made by contacting the administration team.
 
+The device:
+
 - **MUST** 
  
-  - Upload the device's buildable sources to [PixelExperience-Devices](https://github.com/PixelExperience-Devices) organization. 
+  - Have the device's buildable sources uploaded to [PixelExperience-Devices](https://github.com/PixelExperience-Devices) organization. 
   
   - Have hardware compatibility comparable to stock ROMs.
     

--- a/device_requirements.md
+++ b/device_requirements.md
@@ -14,21 +14,21 @@ The device:
     
   - Include some commits listed [here](https://github.com/PixelExperience-Devices/required_commits) in device's trees.
     
-  - Ship builds with AOSP recovery available by us for devices using A/B or dynamic parition layout.
+  - Ship builds with AOSP recovery available by us if the device uses A/B or dynamic parition layout.
     
   - Pass SafetyNet out of the box with no modifications. Other devices' fingerprint **SHOULD** be used if stock device's fingeprint does not pass SafetyNet.
 
 - **MUST NOT**
 
-  - Ship Google Play System Updates/Updatable APEX enabled if the device uses kernel version 3.18 or below, or uses Full Disk Encryption (a.k.a FDE).
+  - Ship builds with Google Play System Updates/Updatable APEX if the device uses kernel version 3.18 or below, or uses Full Disk Encryption (a.k.a FDE).
     
-  - Ship builds with pre-built kernels, unless it's the only solution to make the device functional.
+  - Ship builds with pre-built kernels.
     
   - Ship builds with pre-built TWRP if the device uses A/B partition or dynamic parition layout.
 
-  - Inlucde any features in their device-specific packages (i.e. configpanel, XiaomiParts, ...).
+  - Include any features in device-specific packages (i.e. configpanel, XiaomiParts, ...) or any stock firmware camera apps that are not available from the ROM sources.
     
-  - Include any Google applications or similar applications to getting Pixel-like features that aren't available from the ROM sources.
+  - Include any Google applications or similar applications to getting Pixel-like features that are not available from the ROM sources.
     
   - Include any stock firmware camera app.
 
@@ -36,7 +36,7 @@ The device:
   
   - Include placebo 'tweaks' and/or packages that contain unnecessary and/or unwanted features.
     
-  - Include heavy software modification that may lead to Magisk working improperly
+  - Include heavy software modification that may lead to Magisk working improperly.
  
 - **SHOULD**  <br>
 
@@ -48,21 +48,22 @@ The device:
     
 # Patches
 
+If the device requires patches to a repo others than the device's specific ones, **MUST** make a patch submitting to [PixelExprience's Gerrit](https://gerrit.pixelexperience.org) and have the following qualities:
+
 - Be **REQUIRED** for the device to build and/or boot successfully, or to enable a function (i.e. Fingerprint On Display).
   
 - Have proper authorship.
 
-- Be pushed to [PixelExprience's Gerrit](https://gerrit.pixelexperience.org).
-
 - Be as minimal and as polished as possible.
 
-- Be in accordance with all requirements above.
+- Be in accordance with all the requirements above.
 
 # Exceptions
 Device(s)        | Exception(s)                          | Until | Notes
 -----------------|---------------------------------------|-------|-------------------------------------------------------------------------------------
 All              | VoLTE & NFC                           |       |
 All              | Sources Upload                        |       |Must be from LineageOS, TheMuppets or Sony Open Devices Project (SODP) organizations.
+All              | Pre-built kernels                     |       | Only for devices unable to boot without using pre-built kernels.
 Xiaomi Devices   | Dirac Sound & XiaomiParts             |       |
 OnePlus Devices  | Alert Sliders & Offscreen Gestures    |       |
 Motorola Devices | Fingerprint Gestures & MotoActions    |       |

--- a/maintainers_code_of_conduct.md
+++ b/maintainers_code_of_conduct.md
@@ -4,7 +4,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 Exceptions **SHOULD** be made by contacting the administration team.
 
-The maintainers:
+Maintainers:
 
 - **MUST** uploads changelogs for each build. These **MUST** be user-friendly.
 

--- a/maintainers_code_of_conduct.md
+++ b/maintainers_code_of_conduct.md
@@ -1,45 +1,25 @@
-# Maintainers conduct notes:
+# Maintainers' Code of Conduct:
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+Exceptions **SHOULD** be made by contacting the administration team.
 
 The maintainers:
 
-1 - MUST NOT get involved in arguments or resort to insults, or use hateful words, personal attacks or any other verbal or nonverbal action that is considered detrimental towards the creation of a positive environment for the team.  
+- **MUST** uploads changelogs for each build. These **MUST** be user-friendly.
 
-2 - MUST upload:
+- **MUST** test every build before sending an OTA update to users. Each build must be thoroughly vetted by the maintainer before it is released, and all hardware and software functionalities **MUST** be tested before a build is released. Releasing untested builds **SHALL** lead to your maintainership being revoked.
 
-2.1 - All theirs device sources on [PixelExperience-Devices](https://github.com/PixelExperience-Devices) organization. It goes without saying that these should be fully buildable. Using external repos for build releases aren't allowed, unless they're from LineageOS/TheMuppets and Sony Open Devices Project (SODP) organizations. Exceptions may be open if only it's a really big need.
+- **MUST** ship the Standard/Normal Edition builds monthly.
 
-2.2 - Changelogs for each build. These MUST be user-friendly, simplifying the changes for the average user who aren't aware of things like Safetynet or color calibration, but would like to know what has changed since the last update. 
+- **MAY** ship the Plus Builds monthly.
 
-3 - MUST test every build before sending an OTA update to users. Each build must be thoroughly vetted by the maintainer before it is released, and all hardware and software functionalities MUST be tested before a build is released. Releasing untested builds can (and will) lead to your maintainership being revoked.
+- **MUST** maintain authorship of git commits that are pushed, this is a mandatory requirement for ALL repositories. Force-pushes are acceptable, but try to keep them to a minimum.
 
-4 - MUST ship the Standard/Normal Edition builds monthly while shipping the Plus Edition builds is optional. If this is not possible, the reason(s) must be sent to the PE Administration. In the absence of any explanation, a maintainer will be contacted thrice. If there is no satisfactory answer or the administration does not receive a reply, the maintainer will be kicked without any prior warning. 
+- **MUST NOT** get involved in arguments or resort to insults, or use hateful words, personal attacks or any other verbal or nonverbal action that is considered detrimental towards the creation of a positive environment for the team.  
 
-5 - MUST maintain authorship of git commits that are pushed, this is a mandatory requirement for ALL repositories. Force-pushes are acceptable, but try to keep them to a minimum.
+- **MUST** sort disagreements between maintainers out by using direct messages (DMs) on Telegram or XDA.
 
-6 - In the event of any disagreements between maintainers, sort them out via direct messages on Telegram or XDA. Do not take your fights to our chats, approach the administration if you want something sorted out quickly. The same is valid for our public chat. "We don't do this here".
-
-7 - MUST NOT add:
-
-7.1 - Any features in their device specific packages, eg. configpanel, XiaomiParts, etc., like KCAL, force Camera API2, etc.
-
-Features that are device specific and are available in stock firmware, eg. Alert Slider and Offscreen gestures for some OnePlus Devices, Fingerprint Gestures and MotoActions for Motorola Devices, are allowed.
-
-Dirac Sound or any audio enhancer is allowed, but it MUST be a device's ROM stock feature, or else it's not allowed. The same must be working fine; otherwise, it can't be shipped.
-
-7.2 - Playground or anything else related to getting Pixel-like features that aren't available from the ROM sources - only GoogleCamera and ARCore are acceptable. 
-
-7.3 - Any Google applications that aren't available from ROM sources - again, only GoogleCamera is acceptable, but please ensure that you use a reliable source and that the device has proper support for them.
-
-7.4 - Any stock firmware camera app. Once again GoogleCamera still acceptable as per se.
-
-8 - MUST NOT ship builds with prebuilt kernels, unless it's the only solution to make the device functional.
-
-9 - About Magisk, the maintainers MUST NOT:
-
-9.1 - Do any heavy software modification that may lead to Magisk working properly. If possible, recommend to users to stop using Magisk if it's not working properly.
-
-9.2 - Do any modifications that may lead to Magisk not work, as per the [Kernel Guidelines](https://github.com/PixelExperience/docs/blob/master/kernel_guidelines.md).
-
-10 - If maintainer of an A/B partition or a dynamic partition device, then you MUST NOT ship TWRP prebuilt. Instead of TWRP, the maintainer MUST ship the AOSP Recovery available by us.
+- **SHOULD** approach the administration if you want something sorted out quickly.
 
 If any of these rules are broken, the administration will take direct action against the maintainer without prior warning.


### PR DESCRIPTION
- Moved requirements around to where I think they should be.
- Made branding more consistent.
- Moved all exceptions to a separate places.
- Added a notes for the use of MUST, MUST NOT, SHOULD, SHOULD NOT, REQUIRED, ...

I know this is a big change to the device requirements and maintainers' code of conduct but I do think this is a needed change in order to clarify stuffs.

This is my proposal to the device requirements, if things are not needed or need to be changed, please do contact me.