### PR TITLE
XDA: Thirten: Change Image url

### DIFF
--- a/XDA_ThreadTemplate_thirteen.txt
+++ b/XDA_ThreadTemplate_thirteen.txt
@@ -1,7 +1,7 @@
 Thread title: [ROM][13][DEVICE] PixelExperience [AOSP]
 
 [CENTER]
-[img]https://i.imgur.com/TMruzAQ.png[/img]
+[img]https://i.imgur.com/3jmGyjb.png[/img]
 [SIZE="5"][b][color=#1a73e8]PixelExperience for DeviceName [codename][/color][/b][/SIZE]
 
 [SIZE="4"][b][color=#1a73e8]What is this?[/color][/b][/SIZE]


### PR DESCRIPTION
Too big...xda doesnt render it and shows a X mark in place of image. This is a scaled down version

Old - 1920*1920
Current - 4380*2000
New - 1920*891